### PR TITLE
Remove broken 20141104 general county file

### DIFF
--- a/2014/20141104__ia__general__county.csv
+++ b/2014/20141104__ia__general__county.csv
@@ -1,3 +1,0 @@
-Exception at line 14 of input file, in state results
-
-Line: Adair         Election Day     1,157           525              14              71                13              11           4           34            0        1,829


### PR DESCRIPTION
This file contained invalid data and needs to be regenerated.

This concerns issue #32.