### PR TITLE
Narrow bare excepts to Exception across the parsers

### DIFF
--- a/clarity_parser.py
+++ b/clarity_parser.py
@@ -61,7 +61,7 @@ def download_county_files(url, filename):
             z = zipfile.ZipFile(BytesIO(r.content))
             z.extractall()
             precinct_results(sub.name.replace(' ','_').lower(),filename)
-        except:
+        except Exception:
             no_xml.append(sub.name)
 
     print(no_xml)

--- a/parse_2012_excel.py
+++ b/parse_2012_excel.py
@@ -36,7 +36,7 @@ def parse_file(county):
                 try:
                     party = [p for p in PARTIES if p in rc][0]
                     candidate = rc.replace(party, '').strip()
-                except:
+                except Exception:
                     party = None
                     candidate = rc
                 candidates.append({ 'candidate': candidate, 'party': party})

--- a/parse_2014_excel.py
+++ b/parse_2014_excel.py
@@ -111,7 +111,7 @@ def write_csv(results, county):
          for row in results:
              try:
                  w.writerow([row['county'].strip(), row['precinct'], row['office'], row['district'], row['party'], row['candidate'], row['absentee'], row['polling'], row['total']])
-             except:
+             except Exception:
                  if row.get('polling') is not None:
                      w.writerow([row['county'].strip(), row['precinct'], row['office'], row['district'], row['party'], row['candidate'], None, None, row['polling']])
                  elif row.get('absentee') is not None:


### PR DESCRIPTION
flake8 E722. Widens the bare `except:` in `clarity_parser.py`, `parse_2014_excel.py` and `parse_2012_excel.py` to `Exception` so KeyboardInterrupt and SystemExit don't get quietly swallowed.